### PR TITLE
CP navigation links fix

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -9,5 +9,5 @@ Route::prefix('magiclink/')->name('magiclink.')->group(function () {
     Route::patch('/update', [SettingsController::class, 'update'])->name('update');
 
     // Links
-    Route::resource('links', 'Cp\LinksController')->only(['index', 'delete']);
+    Route::resource('links', LinksController::class)->only(['index', 'delete']);
 });

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -93,9 +93,9 @@ final class ServiceProvider extends AddonServiceProvider
             $nav->create('MagicLink')
                 ->icon('link')
                 ->section('Tools')
+                ->route('magiclink.index')
+                ->can('view magiclink settings')
                 ->children([
-                    Nav::item(__('magiclink::cp.settings.settings'))->route('magiclink.index')
-                                                                    ->can('view magiclink settings'),
                     Nav::item(__('magiclink::cp.links.links'))->route('magiclink.links.index')
                                                               ->can('view links'),
                 ]);


### PR DESCRIPTION
Fixes #258  in which the main navigation link in the CP doesn't do anything when clicked, and the child nav links don't appear.

